### PR TITLE
Set isDevelopingAddon to false

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = {
   },
 
   isDevelopingAddon() {
-    return true;
+    return false;
   }
 
 };


### PR DESCRIPTION
If `isDevelopingAddon` returns `true` the template linter of the hosting app lints this addon. The default linting rules produce some errors with the addon.

@queenvictoria Would be great if we can merge it and release a new version.